### PR TITLE
fix: バックエンドのインポートとミドルウェア設定を修正

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,9 +16,7 @@ from middleware.audit_middleware import AuditMiddleware
 # Import monitoring middleware
 from middleware.monitoring_middleware import MonitoringMiddleware
 # Import performance middleware
-from middleware.performance_middleware import (PerformanceMiddleware,
-                                               performance_metrics,
-                                               setup_performance_middleware)
+from middleware.performance_middleware import performance_metrics
 # Import security middleware
 from security.security_headers import SecurityHeadersMiddleware
 
@@ -65,9 +63,6 @@ app.add_middleware(
     TrustedHostMiddleware,
     allowed_hosts=["localhost", "127.0.0.1", "*.vercel.app", "*.supabase.co"]
 )
-
-# Setup performance middleware
-app = setup_performance_middleware(app)
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
## 概要
バックエンドの起動エラーを修正しました。

## 問題
1. `performance_monitor` が存在しないためインポートエラー
2. `setup_performance_middleware()` の実装に問題があり、ミドルウェア初期化エラー

## 修正内容
- `performance_monitor` の不要なインポートを削除
- `setup_performance_middleware()` の呼び出しを削除
- 必要最小限のインポート（`performance_metrics` のみ）に変更

## テスト
- ✅ バックエンドが正常に起動
- ✅ `/` エンドポイントが正常に応答
- ✅ `/health` エンドポイントが正常に応答
- ✅ `/api/content/articles` エンドポイントが正常に応答

## 影響範囲
- `backend/main.py` のみ
- ミドルウェア設定の簡素化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined performance monitoring integration by removing an extra setup layer, simplifying app startup. No user-facing changes; performance metrics remain available.

- Chores
  - Cleaned up unused middleware references to reduce maintenance overhead and keep the codebase lean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->