### PR TITLE
feat: Phase 11-1 Vercel Speed Insights導入

### DIFF
--- a/docs/phase11-1-speed-insights.md
+++ b/docs/phase11-1-speed-insights.md
@@ -1,0 +1,153 @@
+# Phase 11-1: Vercel Speed Insights 導入
+
+## 概要
+
+Vercel Speed Insightsを導入し、Core Web Vitalsに基づいたパフォーマンス測定を強化する。
+
+## 参考資料
+
+- [Vercel Speed Insights Documentation](https://vercel.com/docs/speed-insights)
+
+## 目的
+
+- リアルタイムパフォーマンス測定
+- 地理的分布分析
+- SEO最適化（Google Page Experience）
+- 既存Web Vitals実装との統合
+
+## Speed Insights とは
+
+Vercel公式のパフォーマンス測定ツールで、以下の機能を提供：
+- Core Web Vitals の自動測定
+- Vercelダッシュボードでの可視化
+- デバイス別・環境別・地域別分析
+- ルート別パフォーマンス分析
+
+## 実装内容
+
+### 1. パッケージインストール
+
+```bash
+cd frontend
+npm install @vercel/speed-insights
+```
+
+### 2. Next.js アプリケーションに統合
+
+```typescript
+// frontend/src/app/layout.tsx
+import { SpeedInsights } from '@vercel/speed-insights/next';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <SpeedInsights />
+      </body>
+    </html>
+  );
+}
+```
+
+### 3. 測定されるメトリクス
+
+- **RES** (Real Experience Score): 総合スコア
+- **FCP** (First Contentful Paint): 初回コンテンツ表示
+- **LCP** (Largest Contentful Paint): 最大コンテンツ表示
+- **CLS** (Cumulative Layout Shift): レイアウトシフト
+- **INP** (Interaction to Next Paint): インタラクション応答
+
+## 既存実装との関係
+
+### 既存: カスタムWeb Vitals（Phase 7-4）
+
+**ファイル**:
+- `frontend/src/lib/web-vitals.ts`
+- `frontend/src/components/web-vitals-reporter.tsx`
+
+**機能**:
+- 詳細なログ記録
+- バックエンドへの送信
+- 長期データ保存
+- カスタム分析
+
+### 新規: Speed Insights
+
+**機能**:
+- Vercelダッシュボード統合
+- 地理的分布マップ
+- パーセンタイル分析（P75/P90/P95/P99）
+- リアルタイム監視
+
+### 役割分担
+
+| 機能 | 既存Web Vitals | Speed Insights |
+|------|---------------|----------------|
+| **測定** | ✅ カスタム実装 | ✅ Vercel統合 |
+| **保存** | ✅ 自社DB（無制限） | ⚠️ 7-90日（プラン依存） |
+| **可視化** | ⚠️ カスタム実装必要 | ✅ Vercel Dashboard |
+| **地理分析** | ❌ なし | ✅ あり |
+| **SEO連携** | ⚠️ 手動 | ✅ 自動 |
+| **コスト** | 無料 | 無料 |
+
+**結論**: 両方を併用して相互補完
+
+## コスト
+
+- **追加コスト**: $0（全プランで無料）
+- **データ保存**:
+  - Hobby: 7日間
+  - Pro: 30日間
+  - Enterprise: 最大90日間
+- **npm パッケージサイズ**: 約5KB（軽量）
+
+## データ保存期間対策
+
+Speed Insightsのデータ保存期間が短いため、既存のカスタムWeb Vitals実装で長期保存を継続：
+
+```
+Speed Insights (Vercel Dashboard)
+├─ リアルタイム分析: 7-30日
+└─ 地理的分布、SEO連携
+
+既存Web Vitals (自社DB)
+├─ 長期保存: 無制限
+└─ 詳細ログ、カスタム分析
+```
+
+## プライバシー対応
+
+Speed Insightsはユーザーデータを収集するため、プライバシーポリシーを更新：
+
+**追加する内容**:
+- Vercel Speed Insightsによるパフォーマンスデータ収集
+- 匿名化されたメトリクスの送信
+- オプトアウト方法
+
+## 実装後の確認
+
+### Vercel Dashboard
+1. プロジェクトを選択
+2. "Speed Insights" タブをクリック
+3. メトリクスが表示されることを確認
+
+### フロントエンド
+1. ページアクセス
+2. ネットワークタブで `/_vercel/speed-insights` を確認
+3. データ送信を確認
+
+## 期待される効果
+
+- ✅ **パフォーマンス可視化**: リアルタイムダッシュボード
+- ✅ **SEO向上**: Core Web Vitals改善
+- ✅ **ユーザー体験向上**: データドリブンな最適化
+- ✅ **地理的分析**: 地域別のパフォーマンス把握
+- ✅ **コスト**: 追加コストなし
+
+## 参考リンク
+
+- [Vercel Speed Insights Documentation](https://vercel.com/docs/speed-insights)
+- [Core Web Vitals](https://web.dev/vitals/)
+- [Google Page Experience](https://developers.google.com/search/docs/appearance/page-experience)
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "20.8.0",
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.0",
+        "@vercel/speed-insights": "^1.2.0",
         "autoprefixer": "10.4.0",
         "axios": "^1.12.2",
         "class-variance-authority": "^0.7.0",
@@ -6867,6 +6868,40 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "@types/node": "20.8.0",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.0",
+    "@vercel/speed-insights": "^1.2.0",
     "autoprefixer": "10.4.0",
     "axios": "^1.12.2",
     "class-variance-authority": "^0.7.0",

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -1,5 +1,5 @@
-import { Footer } from '@/components/footer';
-import { Header } from '@/components/header';
+import { Footer } from "@/components/footer";
+import { Header } from "@/components/header";
 
 export default function DocsPage() {
   return (
@@ -7,7 +7,7 @@ export default function DocsPage() {
       <Header />
       <main className="container mx-auto px-4 py-16">
         <h1 className="text-4xl font-bold mb-8">ドキュメント</h1>
-        
+
         <div className="grid gap-8 lg:grid-cols-4">
           <aside className="lg:col-span-1">
             <nav className="space-y-2">
@@ -90,4 +90,3 @@ export default function DocsPage() {
     </div>
   );
 }
-

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ErrorProvider } from '@/components/ErrorProvider';
 import PerformanceMonitor from '@/components/PerformanceMonitor';
 import { PerformanceProvider } from '@/components/PerformanceProvider';
 import { Providers } from '@/components/providers';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
@@ -101,6 +102,7 @@ export default function RootLayout({
             </PerformanceProvider>
           </ErrorProvider>
         </Providers>
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -23,6 +23,7 @@ export default function PrivacyPage() {
               <li>利用履歴（閲覧記事、お気に入り）</li>
               <li>サブスクリプション情報</li>
               <li>技術的情報（IPアドレス、ブラウザ情報）</li>
+              <li>パフォーマンスメトリクス（Vercel Speed Insights経由、匿名化）</li>
             </ul>
           </section>
 
@@ -36,6 +37,7 @@ export default function PrivacyPage() {
               <li>パーソナライズド推薦</li>
               <li>カスタマーサポート</li>
               <li>セキュリティ・不正利用防止</li>
+              <li>パフォーマンス測定・最適化（Core Web Vitals）</li>
             </ul>
           </section>
 


### PR DESCRIPTION
## 概要
Vercel Speed Insightsを導入し、Core Web Vitalsベースのパフォーマンス測定を強化。

## 実装内容
- ✅ @vercel/speed-insights インストール
- ✅ layout.tsxに統合（`<SpeedInsights />`）
- ✅ プライバシーポリシー更新
- ✅ ドキュメント作成

## 機能
- Core Web Vitals自動測定（RES/FCP/LCP/CLS/INP）
- Vercelダッシュボード統合
- 地理的分布マップ
- デバイス別・環境別分析

## コスト
- 追加コスト: $0（全プラン無料）

## 既存実装との関係
- 既存Web Vitals: 詳細ログ・長期保存
- Speed Insights: リアルタイム・地理分析

両方を併用して相互補完。

参考: https://vercel.com/docs/speed-insights

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Integrated Speed Insights to collect anonymized performance metrics (e.g., Core Web Vitals) for improved performance monitoring.

- Documentation
  - Added a comprehensive guide on Speed Insights, including setup, metrics, comparisons, and verification steps.
  - Updated the privacy policy to disclose collection and use of anonymized performance metrics.

- Chores
  - Added the Speed Insights runtime dependency.

- Style
  - Minor formatting cleanups in a documentation page; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->