### PR TITLE
fix: Renderモジュールインポートエラーを解消

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,7 +36,8 @@ COPY --chown=appuser:appuser . .
 # Set environment variables
 ENV PATH=/home/appuser/.local/bin:$PATH \
     PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
## 問題
`ModuleNotFoundError: No module named 'models'`

## 原因
PYTHONPATHが未設定

## 解決
Dockerfileに `PYTHONPATH=/app` 追加

これでRenderデプロイが成功します✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Python runtime environment configuration to explicitly set the module search path, aligning with existing buffering and bytecode settings. This improves consistency and predictability in containerized environments without altering behavior or performance.
  - No changes to features, APIs, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->