### PR TITLE
feat: P1 social media scheduled posts

### DIFF
--- a/.github/workflows/social-media-post.yml
+++ b/.github/workflows/social-media-post.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/docs/twitter-api-integration-guide.md
+++ b/docs/twitter-api-integration-guide.md
@@ -243,7 +243,9 @@ python3 scripts/test_twitter_connection.py
   - 毎日 03:00 UTC に実行
   - 月・水・金はサービス紹介を自動投稿
   - 毎日トレンドハイライトを投稿
+- `workflow_dispatch` で手動実行も可能（例: 新機能告知を即時投稿したい場合）
 - 実行コマンド: `python scripts/post_to_social_media.py ...`
+- `--dry-run` オプションで実際に投稿せず内容確認ができる
 - 環境変数は GitHub Secrets (`TWITTER_*`) から読み込まれます
 
 ---
@@ -260,8 +262,8 @@ python3 scripts/test_twitter_connection.py
 ## 🔄 次のステップ
 
 1. ✅ Twitter API 統合（このドキュメント）
-2. ⏳ 記事公開時自動投稿フック実装
-3. ⏳ 定期自動投稿ワークフロー作成
+2. ✅ 記事公開時自動投稿フック実装
+3. ✅ 定期自動投稿ワークフロー作成
 4. ⏳ SEO 基本設定
 
 ---

--- a/scripts/post_to_social_media.py
+++ b/scripts/post_to_social_media.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Social Media Posting Script
 P1タスク: SNS自動投稿ワークフロー用スクリプト
@@ -21,7 +20,7 @@ env_local = BACKEND_DIR / ".env.local"
 if env_local.exists():
     load_dotenv(env_local)
 
-from services.social_media_service import SocialMediaService  # noqa: E402
+from services.social_media_service import SocialMediaService
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## 変更内容

### P1タスク ステップ3: 定期自動投稿ワークフロー
- GitHub Actions `social-media-post.yml` を追加し、Twitterへの自動投稿をスケジュール化
- サービス紹介投稿（週3回）とトレンドハイライト（毎日）を別ステップで実行
- `scripts/post_to_social_media.py` を追加し、CLIから柔軟に投稿内容を指定可能に
- ドキュメント(`docs/twitter-api-integration-guide.md`)に定期投稿手順を追記

### 技術的詳細
- ワークフローは毎日03:00 UTCに実行、曜日条件でサービス投稿を制御
- `python scripts/post_to_social_media.py --type service|trend ...` を利用
- GitHub SecretsのTwitter認証情報を利用して投稿

## 動作確認
- `python scripts/post_to_social_media.py --type service --dry-run`
- `python scripts/post_to_social_media.py --type trend --title "Daily Trend" --summary "..." --dry-run`

## 手作業が必要な設定
- Twitter API認証情報（TWITTER_*）を GitHub Secrets / Vercel / Render に設定済みであること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated social media posting runs daily at 03:00 UTC with manual trigger support
  * Service introduction posts on Mondays, Wednesdays, and Fridays; daily trend highlights every run
  * Dry-run preview mode to validate post content before publishing and clear success/failure feedback

* **Documentation**
  * Added workflow guide describing scheduling, manual dispatch, dry-run validation, and credential configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->