### PR TITLE
fix: gracefully skip trend analysis when DB offline

### DIFF
--- a/scripts/analyze_trends.py
+++ b/scripts/analyze_trends.py
@@ -14,13 +14,23 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 
 from database import SessionLocal
 from services.trend_analysis_service import TrendAnalysisService
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 
 async def main_async():
     """メイン処理（非同期）"""
     print("🚀 Starting daily trend analysis...")
 
-    db = SessionLocal()
+    db = None
+    try:
+        db = SessionLocal()
+    except OperationalError as exc:
+        print(
+            "⚠️  Database connection failed while starting trend analysis: "
+            f"{exc}. Skipping run."
+        )
+        return
+
     try:
         # トレンド分析実行
         print("📊 Analyzing trends...")
@@ -40,19 +50,27 @@ async def main_async():
         # 結果をJSON出力（オプション）
         output_file = Path(__file__).parent.parent / "public" / "trends-latest.json"
         output_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_file, 'w', encoding='utf-8') as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             json.dump(result, f, ensure_ascii=False, indent=2)
         print(f"✅ Saved to {output_file}")
 
         print("\n🎉 Daily trend analysis completed!")
 
+    except (OperationalError, SQLAlchemyError) as exc:
+        print(
+            "⚠️  Database operation failed during trend analysis: "
+            f"{exc}. Skipping run."
+        )
+        return
     except Exception as e:
         print(f"❌ Error: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
     finally:
-        db.close()
+        if db:
+            db.close()
 
 
 def main():
@@ -62,4 +80,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- catch OperationalError/SQLAlchemyError in scripts/analyze_trends.py so network outages to Supabase don't fail the workflow
- close DB session safely only when it exists and log clear skip messages

## Testing
- black scripts/analyze_trends.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for database operations to prevent failures during trend analysis runs.

* **Chores**
  * Minor formatting adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->