### PR TITLE
fix(ci): GitHub Actions 失敗の修正（マイグレーション・バックアップ・auto-fix）

### DIFF
--- a/.github/workflows/scheduled-backup.yml
+++ b/.github/workflows/scheduled-backup.yml
@@ -55,13 +55,16 @@ jobs:
     name: Cleanup Old Backups
     runs-on: ubuntu-latest
     needs: backup
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Remove old artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const days = 7;

--- a/.github/workflows/workflow-auto-fix.yml
+++ b/.github/workflows/workflow-auto-fix.yml
@@ -164,14 +164,22 @@ jobs:
             }
 
             core.setOutput('error_log', errorLog);
+            core.setOutput(
+              'error_log_b64',
+              Buffer.from(errorLog || '', 'utf8').toString('base64'),
+            );
             core.setOutput('error_step', errorStep);
 
       - name: Determine error type
         id: error-type
         run: |
           ERROR_MSG="${{ steps.workflow-run.outputs.error_message }}"
-          ERROR_LOG="${{ steps.logs.outputs.error_log }}"
+          ERROR_LOG_B64="${{ steps.logs.outputs.error_log_b64 }}"
           ERROR_STEP="${{ steps.logs.outputs.error_step }}"
+          ERROR_LOG=""
+          if [ -n "$ERROR_LOG_B64" ]; then
+            ERROR_LOG=$(printf '%s' "$ERROR_LOG_B64" | base64 -d 2>/dev/null || true)
+          fi
 
           # ERROR_LOGを安全に処理（特殊文字をエスケープ、長すぎる場合は切り詰め）
           # 改行をスペースに置換し、制御文字を削除

--- a/.github/workflows/workflow-auto-fix.yml
+++ b/.github/workflows/workflow-auto-fix.yml
@@ -207,7 +207,7 @@ jobs:
             ERROR_TYPE="lint"
           fi
 
-          echo "error_type=$ERROR_TYPE" >> $GITHUB_OUTPUT
+          echo "error_type=$ERROR_TYPE" >> "$GITHUB_OUTPUT"
           echo "Detected error type: $ERROR_TYPE"
 
           # デバッグ情報を出力

--- a/backend/alembic/versions/2a3b4c5d6e7f_add_valid_until_and_session_id_to_affiliate.py
+++ b/backend/alembic/versions/2a3b4c5d6e7f_add_valid_until_and_session_id_to_affiliate.py
@@ -19,39 +19,65 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-def upgrade() -> None:
-    """Upgrade schema."""
-    # Add valid_until to referral_links table
-    op.add_column(
-        "referral_links",
-        sa.Column("valid_until", sa.DateTime(), nullable=True),
-    )
-    op.create_index(
-        op.f("ix_referral_links_valid_until"),
-        "referral_links",
-        ["valid_until"],
-        unique=False,
-    )
+def _index_names(inspector, table: str) -> set[str]:
+    return {i["name"] for i in inspector.get_indexes(table)}
 
-    # Add session_id to click_tracking table
-    op.add_column(
-        "click_tracking",
-        sa.Column("session_id", sa.String(), nullable=True),
-    )
-    op.create_index(
-        op.f("ix_click_tracking_session_id"),
-        "click_tracking",
-        ["session_id"],
-        unique=False,
-    )
+
+def upgrade() -> None:
+    """Upgrade schema (idempotent for partially-applied DBs)."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    ref_cols = {c["name"] for c in inspector.get_columns("referral_links")}
+    if "valid_until" not in ref_cols:
+        op.add_column(
+            "referral_links",
+            sa.Column("valid_until", sa.DateTime(), nullable=True),
+        )
+    inspector = sa.inspect(bind)
+    idx_ref = op.f("ix_referral_links_valid_until")
+    if idx_ref not in _index_names(inspector, "referral_links"):
+        op.create_index(
+            idx_ref,
+            "referral_links",
+            ["valid_until"],
+            unique=False,
+        )
+
+    click_cols = {c["name"] for c in inspector.get_columns("click_tracking")}
+    if "session_id" not in click_cols:
+        op.add_column(
+            "click_tracking",
+            sa.Column("session_id", sa.String(), nullable=True),
+        )
+    inspector = sa.inspect(bind)
+    idx_click = op.f("ix_click_tracking_session_id")
+    if idx_click not in _index_names(inspector, "click_tracking"):
+        op.create_index(
+            idx_click,
+            "click_tracking",
+            ["session_id"],
+            unique=False,
+        )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    # Remove indexes
-    op.drop_index(op.f("ix_click_tracking_session_id"), table_name="click_tracking")
-    op.drop_index(op.f("ix_referral_links_valid_until"), table_name="referral_links")
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
 
-    # Remove columns
-    op.drop_column("click_tracking", "session_id")
-    op.drop_column("referral_links", "valid_until")
+    idx_click = op.f("ix_click_tracking_session_id")
+    if idx_click in _index_names(inspector, "click_tracking"):
+        op.drop_index(idx_click, table_name="click_tracking")
+
+    idx_ref = op.f("ix_referral_links_valid_until")
+    if idx_ref in _index_names(inspector, "referral_links"):
+        op.drop_index(idx_ref, table_name="referral_links")
+
+    click_cols = {c["name"] for c in inspector.get_columns("click_tracking")}
+    if "session_id" in click_cols:
+        op.drop_column("click_tracking", "session_id")
+
+    ref_cols = {c["name"] for c in inspector.get_columns("referral_links")}
+    if "valid_until" in ref_cols:
+        op.drop_column("referral_links", "valid_until")

--- a/backend/alembic/versions/c7d9f2a1b4e0_merge_three_heads.py
+++ b/backend/alembic/versions/c7d9f2a1b4e0_merge_three_heads.py
@@ -1,0 +1,28 @@
+"""merge three alembic heads (analytics + affiliate branches)
+
+Revision ID: c7d9f2a1b4e0
+Revises: 9e13f1c94b71, 2a3b4c5d6e7f, 8e2f13c5d7b8
+Create Date: 2026-04-12
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "c7d9f2a1b4e0"
+down_revision: Union[str, Sequence[str], None] = (
+    "9e13f1c94b71",
+    "2a3b4c5d6e7f",
+    "8e2f13c5d7b8",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Merge branches; schema changes live in parent revisions."""
+    pass
+
+
+def downgrade() -> None:
+    """Split is not supported for merge revisions."""
+    pass

--- a/backend/database_config.py
+++ b/backend/database_config.py
@@ -143,11 +143,9 @@ def check_database_health() -> dict:
             pool_info = get_connection_info()
 
             # Get database size
-            size_result = conn.execute(
-                """
+            size_result = conn.execute("""
                 SELECT pg_size_pretty(pg_database_size(current_database())) as db_size
-            """
-            ).fetchone()
+            """).fetchone()
 
             return {
                 "status": "healthy",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,9 @@ psycopg[binary]>=3.2.0  # Supabase PostgreSQL接続用（Python 3.13対応）
 psycopg2-binary>=2.9.0  # Alembic/autogenerate用
 alembic==1.13.2
 
+# Payments (Stripe checkout / webhooks)
+stripe>=8.0.0,<13.0.0
+
 # Authentication and Security
 PyJWT==2.10.1
 passlib[bcrypt]==1.7.4
@@ -28,6 +31,9 @@ groq==0.11.0
 # Image processing
 Pillow==10.4.0
 
+# Caching (Redis client; REDIS_URL used in CI and production)
+redis>=5.0.0,<6.0.0
+
 # Monitoring and metrics
 psutil==5.9.6
 # asyncpg==0.29.0  # Disabled: Not compatible with Python 3.13, not needed for SQLite
@@ -41,4 +47,4 @@ structlog==24.1.0
 tweepy>=4.16.0  # Twitter API v2 client
 
 # Development and testing
-pytest==7.4.0
+pytest==7.4.3

--- a/backend/scripts/auto_fix_migrations.py
+++ b/backend/scripts/auto_fix_migrations.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Automatically detect and fix common migration issues."""
+
 import importlib.util
 import sys
 from pathlib import Path

--- a/backend/scripts/check_migration_4741.py
+++ b/backend/scripts/check_migration_4741.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Check if migration 4741adeef488 is applied."""
+
 import sys
 from pathlib import Path
 

--- a/backend/scripts/detect_migration_issues.py
+++ b/backend/scripts/detect_migration_issues.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Detect migration issues like duplicate revision IDs and multiple heads."""
+
 import re
 import sys
 from collections import defaultdict

--- a/backend/scripts/fix_duplicate_revisions.py
+++ b/backend/scripts/fix_duplicate_revisions.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Fix duplicate revision IDs by renaming one of them."""
+
 import re
 import secrets
 import sys

--- a/backend/scripts/fix_migration_chain.py
+++ b/backend/scripts/fix_migration_chain.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Fix broken migration chain by stamping to appropriate revision."""
+
 import sys
 from pathlib import Path
 

--- a/backend/scripts/fix_missing_revision_references.py
+++ b/backend/scripts/fix_missing_revision_references.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Fix migration files that reference non-existent revisions."""
+
 import re
 import sys
 from pathlib import Path

--- a/backend/scripts/fix_multiple_heads.py
+++ b/backend/scripts/fix_multiple_heads.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Fix multiple head revisions by creating a merge migration or selecting the correct head."""
+
 import sys
 from pathlib import Path
 

--- a/backend/services/monitoring_service.py
+++ b/backend/services/monitoring_service.py
@@ -9,7 +9,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import aiohttp
-import asyncpg
 import psutil
 from fastapi import Depends
 from sqlalchemy.orm import Session

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -43,8 +43,12 @@ backup_database() {
     log_info "データベースをバックアップ中..."
     
     if [ ! -f "$DB_FILE" ]; then
-        log_warning "データベースファイルが見つかりません: $DB_FILE（CI/本番PostgreSQLではローカルDB無しのためスキップ）"
-        return 0
+        if [ "${ALLOW_MISSING_DB:-0}" = "1" ] || [ "${CI:-}" = "true" ]; then
+            log_warning "データベースファイルが見つかりません: $DB_FILE（ALLOW_MISSING_DB=1 または CI=true のためスキップ）"
+            return 0
+        fi
+        log_error "データベースファイルが見つかりません: $DB_FILE"
+        return 1
     fi
     
     # SQLiteバックアップ
@@ -87,6 +91,11 @@ backup_config() {
 
 create_backup_manifest() {
     log_info "バックアップマニフェストを作成中..."
+    local total_size
+    total_size=$(du -sh "$BACKUP_DIR/${BACKUP_NAME}"* 2>/dev/null | awk '{s+=$1}END{print s}')
+    if [ -z "${total_size//[[:space:]]/}" ]; then
+        total_size="n/a"
+    fi
     
     cat > "$BACKUP_DIR/${BACKUP_NAME}_manifest.json" <<EOF
 {
@@ -100,7 +109,7 @@ create_backup_manifest() {
   },
   "sizes": {
     "database": "$(if [ -f "$BACKUP_DIR/${BACKUP_NAME}.db" ]; then du -h "$BACKUP_DIR/${BACKUP_NAME}.db" | cut -f1; else echo "n/a"; fi)",
-    "total": "$(du -sh "$BACKUP_DIR/${BACKUP_NAME}"* 2>/dev/null | awk '{s+=$1}END{print s}' || echo "n/a")"
+    "total": "${total_size}"
   }
 }
 EOF

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -43,8 +43,8 @@ backup_database() {
     log_info "データベースをバックアップ中..."
     
     if [ ! -f "$DB_FILE" ]; then
-        log_error "データベースファイルが見つかりません: $DB_FILE"
-        return 1
+        log_warning "データベースファイルが見つかりません: $DB_FILE（CI/本番PostgreSQLではローカルDB無しのためスキップ）"
+        return 0
     fi
     
     # SQLiteバックアップ
@@ -99,8 +99,8 @@ create_backup_manifest() {
     "config": "${BACKUP_NAME}.env.production"
   },
   "sizes": {
-    "database": "$(du -h "$BACKUP_DIR/${BACKUP_NAME}.db" | cut -f1)",
-    "total": "$(du -sh "$BACKUP_DIR/${BACKUP_NAME}"* | awk '{s+=$1}END{print s}')"
+    "database": "$(if [ -f "$BACKUP_DIR/${BACKUP_NAME}.db" ]; then du -h "$BACKUP_DIR/${BACKUP_NAME}.db" | cut -f1; else echo "n/a"; fi)",
+    "total": "$(du -sh "$BACKUP_DIR/${BACKUP_NAME}"* 2>/dev/null | awk '{s+=$1}END{print s}' || echo "n/a")"
   }
 }
 EOF
@@ -146,7 +146,11 @@ main() {
     cleanup_old_backups
     
     # サマリー
-    BACKUP_SIZE=$(du -h "$BACKUP_DIR/${BACKUP_NAME}.tar.gz" | cut -f1)
+    if [ -f "$BACKUP_DIR/${BACKUP_NAME}.tar.gz" ]; then
+      BACKUP_SIZE=$(du -h "$BACKUP_DIR/${BACKUP_NAME}.tar.gz" | cut -f1)
+    else
+      BACKUP_SIZE="n/a"
+    fi
     
     echo ""
     log_success "バックアップ完了！"


### PR DESCRIPTION
## 原因
- **Daily trends / Social / Articles**: Alembic が `9e13f1c94b71` / `2a3b4c5d6e7f` / `8e2f13c5d7b8` の **3 head** になり `upgrade head` が失敗。別実行では **duplicate column valid_until**。
- **Scheduled backup**: CI に `backend/aica_sys.db` が無く `backup.sh` が exit 1。マニフェストの `du` も同様に失敗し得る。
- **Workflow auto-fix**: 取得ログに `<<EOF` 等が含まれると bash が **ヒアドキュメントとして解釈**して構文エラー。

## 対応
- 3 head を束ねる **merge revision `c7d9f2a1b4e0`** を追加。
- affiliate 系マイグレーションを **冪等**（列・インデックス存在チェック）。
- ローカル DB 無しでは DB バックアップをスキップ、マニフェスト／サマリーを安全化。
- エラーログは **base64** で後続 bash に渡す。
- backup cleanup に `actions: write`、`github-script@v7` に更新。

## 確認
- Docker (python:3.11) で `alembic heads` → **単一 head `c7d9f2a1b4e0`**。
- DB ファイル無しで `./scripts/backup.sh` → **exit 0**。

マージ後、main でマイグレーションが通ればスケジュール系ワークフローが再開します。

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows (explicit permissions, action upgrades) and workflow outputs for more robust automation.
  * Added/updated backend dependencies (stripe, redis, pytest).
  * Made database migrations idempotent and added a merge migration to consolidate branches.
  * Minor script formatting and small cleanup (imports, unused import removal).

* **Bug Fixes**
  * Backup process now gracefully handles missing database files and reports sizes as "n/a" when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->