### PR TITLE
fix(ci): Daily Article の Supabase 接続失敗を回避

### DIFF
--- a/.github/workflows/daily-articles.yml
+++ b/.github/workflows/daily-articles.yml
@@ -58,7 +58,6 @@ jobs:
         run: |
           if [ -z "$DATABASE_URL" ]; then
             echo "ACTIVE_DATABASE_URL=" >> "$GITHUB_ENV"
-            echo "DATABASE_URL_SOURCE=missing" >> "$GITHUB_ENV"
             echo "⚠️ DATABASE_URL not set"
             exit 0
           fi
@@ -100,7 +99,8 @@ jobs:
               conn = psycopg2.connect(url, connect_timeout=5)
               conn.close()
               return True
-            except Exception:
+            except Exception as e:
+              print(f"Database connectivity check failed: {e.__class__.__name__}: {e}")
               return False
 
           original = with_sslmode_require(db_url)
@@ -114,11 +114,9 @@ jobs:
               active = direct
               source = "supabase-direct-fallback"
 
+          print(f"::add-mask::{active}")
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as f:
             f.write(f"ACTIVE_DATABASE_URL={active}\n")
-            f.write(f"DATABASE_URL_SOURCE={source}\n")
-
-          print(f"::add-mask::{active}")
           print(f"Resolved DATABASE_URL source: {source}")
           PY
 

--- a/.github/workflows/daily-articles.yml
+++ b/.github/workflows/daily-articles.yml
@@ -52,9 +52,79 @@ jobs:
           cd backend
           pip list | grep -E "(requests|feedparser|sqlalchemy)" || exit 1
 
-      - name: Check database connection
+      - name: Resolve DATABASE_URL for Supabase pooler
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "ACTIVE_DATABASE_URL=" >> "$GITHUB_ENV"
+            echo "DATABASE_URL_SOURCE=missing" >> "$GITHUB_ENV"
+            echo "⚠️ DATABASE_URL not set"
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import os
+          from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+          import psycopg2
+
+          db_url = os.environ["DATABASE_URL"]
+
+          def with_sslmode_require(url: str) -> str:
+            p = urlparse(url)
+            params = dict(parse_qsl(p.query, keep_blank_values=True))
+            params.setdefault("sslmode", "require")
+            return urlunparse(
+              (p.scheme, p.netloc, p.path or "/postgres", p.params, urlencode(params), p.fragment)
+            )
+
+          def candidate_direct_url(url: str) -> str | None:
+            p = urlparse(url)
+            host = p.hostname or ""
+            username = p.username or ""
+            if not host.endswith("pooler.supabase.com"):
+              return None
+            if not username.startswith("postgres."):
+              return None
+            project_ref = username.split(".", 1)[1]
+            if not project_ref:
+              return None
+            password = p.password or ""
+            port = 5432
+            netloc = f"postgres:{password}@db.{project_ref}.supabase.co:{port}"
+            converted = urlunparse((p.scheme, netloc, p.path or "/postgres", p.params, p.query, p.fragment))
+            return with_sslmode_require(converted)
+
+          def can_connect(url: str) -> bool:
+            try:
+              conn = psycopg2.connect(url, connect_timeout=5)
+              conn.close()
+              return True
+            except Exception:
+              return False
+
+          original = with_sslmode_require(db_url)
+          direct = candidate_direct_url(original)
+
+          active = original
+          source = "original"
+
+          if not can_connect(original) and direct:
+            if can_connect(direct):
+              active = direct
+              source = "supabase-direct-fallback"
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as f:
+            f.write(f"ACTIVE_DATABASE_URL={active}\n")
+            f.write(f"DATABASE_URL_SOURCE={source}\n")
+
+          print(f"::add-mask::{active}")
+          print(f"Resolved DATABASE_URL source: {source}")
+          PY
+
+      - name: Check database connection
+        env:
+          DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
           if [ -z "$DATABASE_URL" ]; then
             echo "⚠️ DATABASE_URL not set, skipping database connection check"
@@ -64,7 +134,7 @@ jobs:
 
       - name: Run database migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
           set +e  # 一時的にエラーで停止しない
           if [ -z "$DATABASE_URL" ]; then
@@ -103,7 +173,7 @@ jobs:
       - name: Run article generation
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
           python3 scripts/generate_daily_article.py
 


### PR DESCRIPTION
## Summary
- `Daily Article Generation` の失敗ログ（tenant/user not found）を確認し、提示ログと一致することを検証しました。
- `.github/workflows/daily-articles.yml` に `Resolve DATABASE_URL for Supabase pooler` ステップを追加しました。
- `aws-*.pooler.supabase.com:6543` で `postgres.<project_ref>` ユーザーが失敗した場合、`db.<project_ref>.supabase.co:5432` + `postgres` へ自動フォールバックします。
- 解決した `ACTIVE_DATABASE_URL` を DB 接続確認 / Alembic migration / 記事生成で共通利用します。

## Validation
- `gh run view 24702257688 --log-failed` でエラー照合（提示内容と一致）
- `ruby -e 'require "yaml"; YAML.load_file(...)'` で workflow YAML 構文確認

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Daily article generation workflow now resolves and masks an active database URL for subsequent steps.
  * Adds a connectivity check and fallback selection to choose a reachable DB endpoint when needed.
  * Subsequent migration and article-generation steps use the resolved URL to improve reliability and avoid exposing secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->