### PR TITLE
fix(ci): Daily ArticleワークフローのDB到達不能時失敗を回避

### DIFF
--- a/.github/workflows/daily-articles.yml
+++ b/.github/workflows/daily-articles.yml
@@ -106,15 +106,20 @@ jobs:
           original = with_sslmode_require(db_url)
           direct = candidate_direct_url(original)
 
-          active = original
-          source = "original"
+          active = ""
+          source = "unreachable"
 
-          if not can_connect(original) and direct:
-            if can_connect(direct):
-              active = direct
-              source = "supabase-direct-fallback"
+          if can_connect(original):
+            active = original
+            source = "original"
+          elif direct and can_connect(direct):
+            active = direct
+            source = "supabase-direct-fallback"
+          else:
+            print("No reachable DATABASE_URL candidate found; downstream DB steps will be skipped.")
 
-          print(f"::add-mask::{active}")
+          if active:
+            print(f"::add-mask::{active}")
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as f:
             f.write(f"ACTIVE_DATABASE_URL={active}\n")
           print(f"Resolved DATABASE_URL source: {source}")
@@ -173,6 +178,10 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "⚠️ ACTIVE_DATABASE_URL not resolved, skipping article generation"
+            exit 0
+          fi
           python3 scripts/generate_daily_article.py
 
       - name: Notify on failure


### PR DESCRIPTION
## Summary
- `Resolve DATABASE_URL for Supabase pooler` で original/direct の両方が接続不可な場合、`ACTIVE_DATABASE_URL` を空のままにして到達不能を明示
- 到達可能なURLがある場合のみ `::add-mask::` を適用するように変更
- `Run article generation` で `ACTIVE_DATABASE_URL` 未解決時はエラー終了せず安全にスキップ

## Test plan
- [x] `npm run format:check -- ../.github/workflows/daily-articles.yml` (frontend)
- [x] `npm run lint` (frontend)
- [ ] `python3 -m pytest -q test_simple.py` (backend) ※ローカル環境に pytest 未導入で実行不可

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database connectivity handling in the article generation workflow to gracefully manage unavailable connections, prevent generation failures, and improve diagnostic logging for connection-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->