### PR TITLE
fix(ci): Weekly Newsletter のDB接続失敗時に安全にスキップ

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -21,6 +21,9 @@ jobs:
   generate-newsletter:
     name: Generate Weekly Newsletter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout code
@@ -46,9 +49,81 @@ jobs:
           cd backend
           pip list | grep -E "(sqlalchemy|pydantic)" || exit 1
 
-      - name: Check database connection
+      - name: Resolve DATABASE_URL for Supabase pooler
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "ACTIVE_DATABASE_URL=" >> "$GITHUB_ENV"
+            echo "⚠️ DATABASE_URL not set"
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import os
+          from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+          import psycopg2
+
+          db_url = os.environ["DATABASE_URL"]
+
+          def with_sslmode_require(url: str) -> str:
+            p = urlparse(url)
+            params = dict(parse_qsl(p.query, keep_blank_values=True))
+            params.setdefault("sslmode", "require")
+            return urlunparse(
+              (p.scheme, p.netloc, p.path or "/postgres", p.params, urlencode(params), p.fragment)
+            )
+
+          def candidate_direct_url(url: str) -> str | None:
+            p = urlparse(url)
+            host = p.hostname or ""
+            username = p.username or ""
+            if not host.endswith("pooler.supabase.com"):
+              return None
+            if not username.startswith("postgres."):
+              return None
+            project_ref = username.split(".", 1)[1]
+            if not project_ref:
+              return None
+            password = p.password or ""
+            port = 5432
+            netloc = f"postgres:{password}@db.{project_ref}.supabase.co:{port}"
+            converted = urlunparse((p.scheme, netloc, p.path or "/postgres", p.params, p.query, p.fragment))
+            return with_sslmode_require(converted)
+
+          def can_connect(url: str) -> bool:
+            try:
+              conn = psycopg2.connect(url, connect_timeout=5)
+              conn.close()
+              return True
+            except Exception as e:
+              print(f"Database connectivity check failed: {e.__class__.__name__}: {e}")
+              return False
+
+          original = with_sslmode_require(db_url)
+          direct = candidate_direct_url(original)
+          active = ""
+          source = "unreachable"
+
+          if can_connect(original):
+            active = original
+            source = "original"
+          elif direct and can_connect(direct):
+            active = direct
+            source = "supabase-direct-fallback"
+          else:
+            print("No reachable DATABASE_URL candidate found; downstream DB steps will be skipped.")
+
+          if active:
+            print(f"::add-mask::{active}")
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as f:
+            f.write(f"ACTIVE_DATABASE_URL={active}\n")
+          print(f"Resolved DATABASE_URL source: {source}")
+          PY
+
+      - name: Check database connection
+        env:
+          DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
           if [ -z "$DATABASE_URL" ]; then
             echo "⚠️ DATABASE_URL not set, skipping database connection check"
@@ -64,7 +139,7 @@ jobs:
 
       - name: Check data availability
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
           if [ -z "$DATABASE_URL" ]; then
             echo "⚠️ DATABASE_URL not set, skipping data availability check"
@@ -87,8 +162,12 @@ jobs:
 
       - name: Run newsletter generation
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ env.ACTIVE_DATABASE_URL }}
         run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "⚠️ ACTIVE_DATABASE_URL not resolved, skipping newsletter generation"
+            exit 0
+          fi
           set +e  # 一時的にエラーで停止しない
           SCRIPT_OUTPUT=$(python3 scripts/generate_newsletter.py 2>&1)
           SCRIPT_EXIT_CODE=$?


### PR DESCRIPTION
## Summary
- `Weekly Newsletter Generation` に Supabase pooler用の `DATABASE_URL` 解決ステップを追加（direct fallback含む）
- 到達可能なURLがない場合は `ACTIVE_DATABASE_URL` を空にし、DB依存ステップを安全にスキップ
- 失敗通知の二次エラー対策として `issues: write` 権限をジョブに付与

## Test plan
- [x] `npm run format:check -- ../.github/workflows/weekly-newsletter.yml` (frontend)
- [x] `npm run lint` (frontend)
- [ ] `python3 -m pytest -q test_simple.py` (backend) ※pytest未導入で実行不可

Made with [Cursor](https://cursor.com)