### PR TITLE
fix: prevent production error-loop and CSRF endpoint mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ temp/
 .env*.local
 # TypeScript build info
 *.tsbuildinfo
+
+# Playwright artifacts
+frontend/playwright/***
+frontend/playwright-report/***

--- a/frontend/src/app/api/alerts/error/route.ts
+++ b/frontend/src/app/api/alerts/error/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(_request: NextRequest) {
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/analytics/error/route.ts
+++ b/frontend/src/app/api/analytics/error/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(_request: NextRequest) {
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/csrf/token/route.ts
+++ b/frontend/src/app/api/csrf/token/route.ts
@@ -1,23 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
 import { csrfProtection } from "@/lib/csrf";
+import { randomUUID } from "crypto";
 
 export async function GET(request: NextRequest) {
   try {
-    const session = await getServerSession(authOptions);
-
-    if (!session?.user?.email) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // セッションIDを生成（実際の実装では適切なセッションIDを使用）
-    const sessionId = session.user.email;
+    const sessionId = request.cookies.get("csrf_session_id")?.value || randomUUID();
 
     // CSRFトークンを生成
     const token = csrfProtection.generateToken(sessionId);
 
-    return NextResponse.json({ token });
+    const response = NextResponse.json({ token });
+    response.cookies.set("csrf_session_id", sessionId, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30,
+    });
+    return response;
   } catch (error) {
     console.error("CSRF token generation error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/frontend/src/lib/error-handler.ts
+++ b/frontend/src/lib/error-handler.ts
@@ -25,6 +25,7 @@ export interface AlertConfig {
 
 class ErrorHandler {
   private errors: ErrorLog[] = [];
+  private originalFetch: typeof window.fetch | null = null;
   private alertConfig: AlertConfig = {
     enabled: true,
     threshold: 5,
@@ -72,14 +73,22 @@ class ErrorHandler {
   }
 
   private setupNetworkErrorHandling() {
-    const originalFetch = window.fetch;
+    if (this.originalFetch) {
+      return;
+    }
+
+    this.originalFetch = window.fetch;
     const self = this;
 
     window.fetch = async function (...args) {
-      try {
-        const response = await originalFetch.apply(this, args);
+      const requestUrl = typeof args[0] === "string" ? args[0] : args[0]?.toString() || "";
+      const isInternalErrorReporting =
+        requestUrl.includes("/api/analytics/error") || requestUrl.includes("/api/alerts/error");
 
-        if (!response.ok) {
+      try {
+        const response = await self.originalFetch!.apply(this, args);
+
+        if (!response.ok && !isInternalErrorReporting) {
           self.handleError({
             message: `Network request failed: ${response.status} ${response.statusText}`,
             severity: response.status >= 500 ? "high" : "medium",
@@ -94,6 +103,10 @@ class ErrorHandler {
 
         return response;
       } catch (error) {
+        if (isInternalErrorReporting) {
+          throw error;
+        }
+
         const errorMessage = error instanceof Error ? error.message : String(error);
         const errorStack = error instanceof Error ? error.stack : undefined;
 
@@ -179,7 +192,8 @@ class ErrorHandler {
       }
 
       // Send to custom analytics endpoint
-      await fetch("/api/analytics/error", {
+      const safeFetch = this.originalFetch || fetch;
+      await safeFetch("/api/analytics/error", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -215,8 +229,9 @@ class ErrorHandler {
     };
 
     try {
+      const safeFetch = this.originalFetch || fetch;
       for (const endpoint of this.alertConfig.endpoints) {
-        await fetch(endpoint, {
+        await safeFetch(endpoint, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/frontend/src/lib/security.ts
+++ b/frontend/src/lib/security.ts
@@ -171,7 +171,7 @@ export class SecurityUtils {
 
   static async getCSRFToken(): Promise<string> {
     try {
-      const response = await fetch("/api/csrf-token", {
+      const response = await fetch("/api/csrf/token", {
         method: "GET",
         credentials: "include",
       });
@@ -181,7 +181,7 @@ export class SecurityUtils {
       }
 
       const data = await response.json();
-      return data.csrf_token;
+      return data.token || this.generateCSRFToken();
     } catch (error) {
       console.error("Error getting CSRF token:", error);
       return this.generateCSRFToken();


### PR DESCRIPTION
## Summary
- Prevent recursive error reporting by excluding internal error endpoints from global fetch-based error handling and using safe fetch for telemetry sends
- Fix CSRF token client/server mismatch (`/api/csrf-token` -> `/api/csrf/token`, response key `token`) and issue anonymous CSRF session cookie for unauthenticated users
- Add missing `POST /api/analytics/error` and `POST /api/alerts/error` endpoints to stop 404 spam from telemetry posts

## Evidence
- `vercel logs --project aica-sys --environment production --since 2h --json --no-follow` showed heavy repeated `POST /api/analytics/error` and `POST /api/alerts/error` with `404`
- Same log stream confirmed normal `GET /` and `GET /articles` at `200` in edge middleware, suggesting client-side degradation from request storms rather than route render failure

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test -- --runInBand`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)