### PR TITLE
fix: apply same-origin proxy pattern for all frontend API calls

### DIFF
--- a/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/frontend/src/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000";
+
+const METHODS_WITHOUT_BODY = new Set(["GET", "HEAD"]);
+
+async function forwardToBackend(
+  request: NextRequest,
+  { params }: { params: { path: string[] } },
+): Promise<NextResponse> {
+  const path = params.path?.join("/") || "";
+  const targetUrl = new URL(`/${path}`, BACKEND_URL);
+  targetUrl.search = request.nextUrl.search;
+
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.delete("connection");
+  headers.delete("content-length");
+
+  const body = METHODS_WITHOUT_BODY.has(request.method) ? undefined : await request.arrayBuffer();
+
+  const response = await fetch(targetUrl.toString(), {
+    method: request.method,
+    headers,
+    body,
+    redirect: "manual",
+  });
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+export async function GET(request: NextRequest, context: { params: { path: string[] } }) {
+  return forwardToBackend(request, context);
+}
+
+export async function POST(request: NextRequest, context: { params: { path: string[] } }) {
+  return forwardToBackend(request, context);
+}
+
+export async function PUT(request: NextRequest, context: { params: { path: string[] } }) {
+  return forwardToBackend(request, context);
+}
+
+export async function PATCH(request: NextRequest, context: { params: { path: string[] } }) {
+  return forwardToBackend(request, context);
+}
+
+export async function DELETE(request: NextRequest, context: { params: { path: string[] } }) {
+  return forwardToBackend(request, context);
+}
+
+export async function OPTIONS(request: NextRequest, context: { params: { path: string[] } }) {
+  return forwardToBackend(request, context);
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -35,6 +35,18 @@ export class ApiClient {
     return this.csrfToken;
   }
 
+  private isBrowserProxyMode(): boolean {
+    return typeof window !== "undefined" && /^https?:\/\//.test(this.baseURL);
+  }
+
+  private buildRequestUrl(endpoint: string): string {
+    const normalizedEndpoint = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+    if (this.isBrowserProxyMode()) {
+      return `/api/proxy${normalizedEndpoint}`;
+    }
+    return `${this.baseURL}${normalizedEndpoint}`;
+  }
+
   async request<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
     // Check rate limit
     if (!apiRateLimiter.isAllowed()) {
@@ -43,7 +55,7 @@ export class ApiClient {
       };
     }
 
-    const url = `${this.baseURL}${endpoint}`;
+    const url = this.buildRequestUrl(endpoint);
 
     // Get security headers
     const sessionId = SecurityUtils.getSessionId();
@@ -141,7 +153,6 @@ export class ApiClient {
 
     const queryString = searchParams.toString();
     const endpoint = queryString ? `/articles?${queryString}` : "/articles";
-
     return this.request(endpoint);
   }
 


### PR DESCRIPTION
## Summary
- `ApiClient` のブラウザ実行時通信を共通化し、外部オリジン指定時は `/api/proxy/*` へ自動ルーティング
- Next.js 側に `api/proxy/[...path]` のキャッチオールプロキシを追加し、クエリ・HTTPメソッド・ボディをバックエンドへ透過転送
- `/articles` だけでなく `ApiClient` 経由の他APIも同じ CORS 回避パスに統一

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test -- --runInBand`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)