### PR TITLE
fix: stabilize content loading with backend URL normalization

### DIFF
--- a/backend/routers/content.py
+++ b/backend/routers/content.py
@@ -8,10 +8,87 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from database import get_db
+from models.automated_content import AutomatedContentDB, ContentStatus, ContentType
 from models.collection import AnalysisResult
 from models.content import Article, Newsletter, Trend
 
 router = APIRouter(prefix="/api/content", tags=["content"])
+
+
+def _to_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _automated_to_article(content: AutomatedContentDB) -> dict:
+    metadata = content.content_metadata or {}
+    return {
+        "id": str(content.id),
+        "title": content.title or "",
+        "description": content.summary or "",
+        "summary": content.summary or "",
+        "content": content.content or "",
+        "author": {"name": metadata.get("author", "AICA-SyS")},
+        "category": metadata.get("category", "general"),
+        "tags": metadata.get("tags", []),
+        "publishedAt": content.published_at or content.created_at,
+        "published_at": content.published_at or content.created_at,
+        "readTime": _to_int(metadata.get("read_time", 5), default=5),
+        "read_time": _to_int(metadata.get("read_time", 5), default=5),
+        "views": _to_int(metadata.get("views", 0)),
+        "likes": _to_int(metadata.get("likes", 0)),
+        "isPremium": bool(metadata.get("is_premium", False)),
+        "is_premium": bool(metadata.get("is_premium", False)),
+    }
+
+
+def _automated_to_newsletter(content: AutomatedContentDB) -> dict:
+    metadata = content.content_metadata or {}
+    return {
+        "id": str(content.id),
+        "title": content.title or "",
+        "description": content.summary or "",
+        "content": content.content or "",
+        "publishedAt": content.published_at or content.created_at,
+        "published_at": content.published_at or content.created_at,
+        "subscribers": _to_int(metadata.get("subscribers", 0)),
+        "openRate": _to_float(metadata.get("open_rate", 0)),
+        "open_rate": _to_float(metadata.get("open_rate", 0)),
+        "clickRate": _to_float(metadata.get("click_rate", 0)),
+        "click_rate": _to_float(metadata.get("click_rate", 0)),
+        "isPremium": bool(metadata.get("is_premium", False)),
+        "is_premium": bool(metadata.get("is_premium", False)),
+        "tags": metadata.get("tags", []),
+    }
+
+
+def _automated_to_trend(content: AutomatedContentDB) -> dict:
+    metadata = content.content_metadata or {}
+    return {
+        "id": str(content.id),
+        "title": content.title or "",
+        "description": content.summary or "",
+        "category": metadata.get("category", "general"),
+        "impact": metadata.get("impact", "medium"),
+        "trendScore": _to_float(
+            metadata.get("trend_score", content.quality_score or 0)
+        ),
+        "trend_score": _to_float(
+            metadata.get("trend_score", content.quality_score or 0)
+        ),
+        "relatedArticles": metadata.get("related_articles", []),
+        "related_articles": metadata.get("related_articles", []),
+        "created_at": content.created_at,
+    }
 
 
 @router.get("/articles")
@@ -29,6 +106,29 @@ async def get_articles(
 
     articles = query.offset(skip).limit(limit).all()
     total = query.count()
+
+    if total == 0:
+        automated_query = db.query(AutomatedContentDB).filter(
+            AutomatedContentDB.content_type == ContentType.ARTICLE.value,
+            AutomatedContentDB.status == ContentStatus.PUBLISHED.value,
+        )
+        automated_total = automated_query.count()
+        automated_articles = (
+            automated_query.order_by(AutomatedContentDB.published_at.desc().nullslast())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        if automated_total > 0:
+            return {
+                "articles": [
+                    _automated_to_article(item) for item in automated_articles
+                ],
+                "total": automated_total,
+                "skip": skip,
+                "limit": limit,
+                "source": "automated_contents",
+            }
 
     return {"articles": articles, "total": total, "skip": skip, "limit": limit}
 
@@ -57,6 +157,29 @@ async def get_newsletters(
     """Get list of newsletters"""
     newsletters = db.query(Newsletter).offset(skip).limit(limit).all()
     total = db.query(Newsletter).count()
+
+    if total == 0:
+        automated_query = db.query(AutomatedContentDB).filter(
+            AutomatedContentDB.content_type == ContentType.NEWSLETTER.value,
+            AutomatedContentDB.status == ContentStatus.PUBLISHED.value,
+        )
+        automated_total = automated_query.count()
+        automated_newsletters = (
+            automated_query.order_by(AutomatedContentDB.published_at.desc().nullslast())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        if automated_total > 0:
+            return {
+                "newsletters": [
+                    _automated_to_newsletter(item) for item in automated_newsletters
+                ],
+                "total": automated_total,
+                "skip": skip,
+                "limit": limit,
+                "source": "automated_contents",
+            }
 
     return {"newsletters": newsletters, "total": total, "skip": skip, "limit": limit}
 
@@ -91,6 +214,27 @@ async def get_trends(
 
     trends = query.offset(skip).limit(limit).all()
     total = query.count()
+
+    if total == 0:
+        automated_query = db.query(AutomatedContentDB).filter(
+            AutomatedContentDB.content_type == ContentType.TREND.value,
+            AutomatedContentDB.status == ContentStatus.PUBLISHED.value,
+        )
+        automated_total = automated_query.count()
+        automated_trends = (
+            automated_query.order_by(AutomatedContentDB.published_at.desc().nullslast())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        if automated_total > 0:
+            return {
+                "trends": [_automated_to_trend(item) for item in automated_trends],
+                "total": automated_total,
+                "skip": skip,
+                "limit": limit,
+                "source": "automated_contents",
+            }
 
     return {"trends": trends, "total": total, "skip": skip, "limit": limit}
 

--- a/frontend/src/app/api/content/articles/route.ts
+++ b/frontend/src/app/api/content/articles/route.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://127.0.0.1:8000";
+const BACKEND_URL = resolveBackendUrl();
 
 export async function GET(request: NextRequest) {
   try {

--- a/frontend/src/app/api/content/newsletters/route.ts
+++ b/frontend/src/app/api/content/newsletters/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://127.0.0.1:8000";
+const BACKEND_URL = resolveBackendUrl();
 
 export async function GET(request: NextRequest) {
   try {

--- a/frontend/src/app/api/content/trends/route.ts
+++ b/frontend/src/app/api/content/trends/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://127.0.0.1:8000";
+const BACKEND_URL = resolveBackendUrl();
 
 export async function GET(request: NextRequest) {
   try {

--- a/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/frontend/src/app/api/proxy/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
-const BACKEND_URL = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000";
+const BACKEND_URL = resolveBackendUrl();
 
 const METHODS_WITHOUT_BODY = new Set(["GET", "HEAD"]);
 const CONTENT_FALLBACK_PATHS = new Set(["articles", "newsletters", "trends"]);
@@ -23,6 +24,7 @@ function getFallbackResponse(path: string): NextResponse | null {
           title: "TypeScript 5.0の新機能とベストプラクティス",
           description:
             "バックエンド疎通に失敗したため、フォールバック記事を表示しています。環境復旧後に最新データへ切り替わります。",
+          content: "",
           category: "tutorial",
           tags: ["TypeScript", "Fallback"],
           publishedAt: "2024-01-15T10:00:00Z",
@@ -45,11 +47,13 @@ function getFallbackResponse(path: string): NextResponse | null {
           id: "fallback-newsletter-1",
           title: "TypeScript Weekly フォールバック版",
           description: "バックエンド未接続時の代替ニュースレターです。",
+          content: "",
           publishedAt: "2024-01-15T10:00:00Z",
           subscribers: 1000,
           openRate: 75,
           clickRate: 25,
           isPremium: false,
+          tags: ["Fallback"],
         },
       ],
       total: 1,

--- a/frontend/src/hooks/use-articles.ts
+++ b/frontend/src/hooks/use-articles.ts
@@ -29,6 +29,38 @@ interface Filters {
   search: string;
 }
 
+function normalizeAuthor(rawAuthor: any): { name: string; avatar?: string } {
+  if (typeof rawAuthor === "string" && rawAuthor.trim()) {
+    return { name: rawAuthor };
+  }
+  if (rawAuthor && typeof rawAuthor === "object") {
+    return {
+      name: rawAuthor.name ?? "AICA-SyS",
+      avatar: rawAuthor.avatar,
+    };
+  }
+  return { name: "AICA-SyS" };
+}
+
+function normalizeArticle(article: any): Article {
+  const rawTags = article?.tags;
+  return {
+    id: String(article?.id ?? ""),
+    title: article?.title ?? "Untitled",
+    description: article?.description ?? article?.summary ?? "",
+    content: article?.content ?? "",
+    author: normalizeAuthor(article?.author),
+    category: article?.category ?? "general",
+    tags: Array.isArray(rawTags) ? rawTags : [],
+    publishedAt: article?.publishedAt ?? article?.published_at ?? new Date().toISOString(),
+    readTime: Number(article?.readTime ?? article?.read_time ?? 0),
+    views: Number(article?.views ?? 0),
+    likes: Number(article?.likes ?? 0),
+    isPremium: Boolean(article?.isPremium ?? article?.is_premium ?? false),
+    imageUrl: article?.imageUrl ?? article?.image_url,
+  };
+}
+
 export function useArticles(filters: Filters) {
   const { data: session } = useSession();
 
@@ -45,7 +77,7 @@ export function useArticles(filters: Filters) {
         throw new Error(response.error);
       }
 
-      return response.data?.articles || [];
+      return (response.data?.articles || []).map(normalizeArticle);
     },
     // モックデータを返す（実際の実装ではAPIから取得）
     placeholderData: () => [

--- a/frontend/src/hooks/use-newsletters.ts
+++ b/frontend/src/hooks/use-newsletters.ts
@@ -17,6 +17,23 @@ interface Newsletter {
   tags: string[];
 }
 
+function normalizeNewsletter(newsletter: any): Newsletter {
+  const rawTags = newsletter?.tags;
+  return {
+    id: String(newsletter?.id ?? ""),
+    title: newsletter?.title ?? "Untitled",
+    description: newsletter?.description ?? newsletter?.summary ?? "",
+    content: newsletter?.content ?? "",
+    publishedAt: newsletter?.publishedAt ?? newsletter?.published_at ?? new Date().toISOString(),
+    subscribers: Number(newsletter?.subscribers ?? 0),
+    openRate: Number(newsletter?.openRate ?? newsletter?.open_rate ?? 0),
+    clickRate: Number(newsletter?.clickRate ?? newsletter?.click_rate ?? 0),
+    isPremium: Boolean(newsletter?.isPremium ?? newsletter?.is_premium ?? false),
+    imageUrl: newsletter?.imageUrl ?? newsletter?.image_url,
+    tags: Array.isArray(rawTags) ? rawTags : [],
+  };
+}
+
 export function useNewsletters() {
   const query = useQuery({
     queryKey: ["newsletters"],
@@ -27,7 +44,7 @@ export function useNewsletters() {
         throw new Error(response.error);
       }
 
-      return response.data?.newsletters || [];
+      return (response.data?.newsletters || []).map(normalizeNewsletter);
     },
     // モックデータを返す（実際の実装ではAPIから取得）
     placeholderData: () => [

--- a/frontend/src/lib/backend-url.ts
+++ b/frontend/src/lib/backend-url.ts
@@ -1,0 +1,24 @@
+const DEFAULT_BACKEND_URL = "https://aica-sys.onrender.com";
+
+const DEPRECATED_BACKEND_HOSTS = new Set(["aica-sys-backend.onrender.com"]);
+
+function withDefaultProtocol(url: string): string {
+  if (/^https?:\/\//.test(url)) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
+export function resolveBackendUrl(): string {
+  const raw = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || DEFAULT_BACKEND_URL;
+
+  try {
+    const parsed = new URL(withDefaultProtocol(raw));
+    if (DEPRECATED_BACKEND_HOSTS.has(parsed.hostname)) {
+      return DEFAULT_BACKEND_URL;
+    }
+    return parsed.origin;
+  } catch {
+    return DEFAULT_BACKEND_URL;
+  }
+}


### PR DESCRIPTION
## Summary
- 正式な Render ホストへ自動正規化する `resolveBackendUrl()` を導入し、旧ホスト参照で発生する fallback 固定表示を防止
- `useArticles` / `useNewsletters` にレスポンス正規化を追加し、`tags` 欠落や snake_case 混在時のランタイムクラッシュを解消
- backend `/api/content/*` でテーブル空時に `automated_contents` をフォールバック参照し、公開済みデータを継続配信

## Test plan
- [x] `frontend`: `npm run lint`
- [x] `frontend`: `npm run format:check`
- [x] `frontend`: `npm run type-check`
- [x] `frontend`: `npm run test -- --runInBand`
- [x] `backend`: `./venv/bin/python -m black --check routers/content.py`
- [x] `backend`: `./venv/bin/python -m pytest`
- [x] `curl https://aica-sys.vercel.app/api/proxy/articles?sortBy=newest` が 200 かつ fallback 形式を返すことを確認
- [x] `curl https://aica-sys.vercel.app/api/proxy/newsletters` が 200 かつ fallback 形式を返すことを確認
- [x] Supabase REST で `automated_contents` にデータがあり、`articles/newsletters/trends` が 0 件である現状を確認

Made with [Cursor](https://cursor.com)