### PR TITLE
fix(frontend): stop /articles telemetry error cascade

### DIFF
--- a/frontend/src/app/api/analytics/performance/route.ts
+++ b/frontend/src/app/api/analytics/performance/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(_request: NextRequest) {
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ErrorProvider } from "@/components/ErrorProvider";
 import PerformanceMonitor from "@/components/PerformanceMonitor";
 import { PerformanceProvider } from "@/components/PerformanceProvider";
 import { Providers } from "@/components/providers";
+import { getSanitizedGaId } from "@/lib/analytics-config";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
@@ -19,7 +20,7 @@ const inter = Inter({
 
 const SITE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://aica-sys.vercel.app";
 const GOOGLE_SITE_VERIFICATION = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION;
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID;
+const GA_MEASUREMENT_ID = getSanitizedGaId(process.env.NEXT_PUBLIC_GA_ID);
 const DEFAULT_DESCRIPTION =
   "TypeScriptエコシステム特化型のAI自動コンテンツ生成・販売システム。最新トレンド、技術記事、ニュースレターを自動配信。";
 const DEFAULT_KEYWORDS = [

--- a/frontend/src/lib/analytics-config.ts
+++ b/frontend/src/lib/analytics-config.ts
@@ -1,0 +1,8 @@
+const GA_ID_PATTERN = /^G-[A-Z0-9]+$/i;
+
+export function getSanitizedGaId(rawValue?: string): string {
+  const trimmed = (rawValue || "").trim();
+  if (!trimmed) return "";
+  if (!GA_ID_PATTERN.test(trimmed)) return "";
+  return trimmed;
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,18 +1,20 @@
 "use client";
 
+import { getSanitizedGaId } from "./analytics-config";
+
 declare global {
   interface Window {
     gtag: (...args: any[]) => void;
   }
 }
 
-export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID || "";
+export const GA_TRACKING_ID = getSanitizedGaId(process.env.NEXT_PUBLIC_GA_ID);
 
 export class Analytics {
   private static isInitialized = false;
 
   static init() {
-    if (typeof window === "undefined" || this.isInitialized) return;
+    if (typeof window === "undefined" || this.isInitialized || !GA_TRACKING_ID) return;
 
     // Load Google Analytics script
     const script = document.createElement("script");


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_GA_ID` をサニタイズして改行/不正値を除去し、`GoogleAnalytics` スクリプト注入時の構文エラーを防止
- `analytics.ts` 側でも同じサニタイズ済み ID を使い、無効ID時は GA 初期化をスキップ
- 未実装だった `POST /api/analytics/performance` を追加して 404 を解消し、エラーハンドラの過剰発火を抑制

## Test plan
- [x] `frontend`: `npm run lint`
- [x] `frontend`: `npm run format:check`
- [x] `frontend`: `npm run type-check`
- [x] `frontend`: `npm run test -- --runInBand`
- [x] `curl -X POST https://aica-sys.vercel.app/api/analytics/error` が 200 を返すことを確認
- [x] `curl -X POST https://aica-sys.vercel.app/api/alerts/error` が 200 を返すことを確認

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a performance analytics API endpoint.

* **Bug Fixes**
  * Enhanced Google Analytics ID validation to properly sanitize and verify configuration format.
  * Analytics initialization now aborts with invalid or missing configuration to prevent failed tracking setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->