### PR TITLE
fix(frontend): reduce false-positive telemetry on articles page

### DIFF
--- a/frontend/src/lib/error-handler.ts
+++ b/frontend/src/lib/error-handler.ts
@@ -84,11 +84,13 @@ class ErrorHandler {
       const requestUrl = typeof args[0] === "string" ? args[0] : args[0]?.toString() || "";
       const isInternalErrorReporting =
         requestUrl.includes("/api/analytics/error") || requestUrl.includes("/api/alerts/error");
+      const isApiRequest = requestUrl.includes("/api/");
 
       try {
         const response = await self.originalFetch!.apply(this, args);
 
-        if (!response.ok && !isInternalErrorReporting) {
+        // Ignore non-API requests and expected 4xx responses to avoid noisy telemetry.
+        if (!isInternalErrorReporting && isApiRequest && response.status >= 500) {
           self.handleError({
             message: `Network request failed: ${response.status} ${response.statusText}`,
             severity: response.status >= 500 ? "high" : "medium",
@@ -104,6 +106,10 @@ class ErrorHandler {
         return response;
       } catch (error) {
         if (isInternalErrorReporting) {
+          throw error;
+        }
+
+        if (!isApiRequest) {
           throw error;
         }
 


### PR DESCRIPTION
## Summary
- `error-handler` の fetch 監視を調整し、`/api/*` 以外の失敗はエラー送信対象から除外
- API でも 4xx は通知対象から外し、5xx のみを高優先で送信するように変更
- これにより `/articles` 表示時の `/api/analytics/error` と `/api/alerts/error` の過剰発火を抑制

## Test plan
- [x] `frontend`: `npm run lint`
- [x] `frontend`: `npm run format:check`
- [x] `frontend`: `npm run type-check`
- [x] `frontend`: `npm run test -- --runInBand`
- [x] `POST /api/analytics/performance` が 200 を返すことを確認
- [x] Browser検証で `Invalid or unexpected token` が再発しないことを確認

Made with [Cursor](https://cursor.com)