### PR TITLE
fix(frontend): preserve article/newsletter cards on transient fetch errors

### DIFF
--- a/frontend/src/app/articles/page.tsx
+++ b/frontend/src/app/articles/page.tsx
@@ -17,6 +17,7 @@ export default function ArticlesPage() {
   });
 
   const { articles, isLoading, error } = useArticles(filters);
+  const hasArticles = articles.length > 0;
 
   return (
     <div className="min-h-screen bg-background">
@@ -38,20 +39,20 @@ export default function ArticlesPage() {
           <ArticleFilters filters={filters} onFiltersChange={setFilters} />
         </div>
 
-        {isLoading ? (
+        {isLoading && !hasArticles ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="h-64 animate-pulse bg-muted rounded-lg"></div>
             ))}
           </div>
-        ) : error ? (
+        ) : error && !hasArticles ? (
           <div className="text-center py-12">
             <p className="text-muted-foreground">記事の読み込みに失敗しました</p>
             <Button variant="outline" className="mt-4">
               再試行
             </Button>
           </div>
-        ) : articles.length === 0 ? (
+        ) : !hasArticles ? (
           <div className="text-center py-12">
             <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
             <h3 className="text-lg font-semibold mb-2">記事が見つかりません</h3>
@@ -59,14 +60,21 @@ export default function ArticlesPage() {
             <Button variant="outline">フィルターをリセット</Button>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {articles.map((article) => (
-              <ArticleCard key={article.id} article={article} />
-            ))}
-          </div>
+          <>
+            {error ? (
+              <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                最新データ取得に失敗したため、利用可能な記事を表示しています。
+              </div>
+            ) : null}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {articles.map((article) => (
+                <ArticleCard key={article.id} article={article} />
+              ))}
+            </div>
+          </>
         )}
 
-        {articles.length > 0 && (
+        {hasArticles && (
           <div className="mt-12 text-center">
             <Button variant="outline">さらに読み込む</Button>
           </div>

--- a/frontend/src/app/newsletters/page.tsx
+++ b/frontend/src/app/newsletters/page.tsx
@@ -9,6 +9,7 @@ import { Plus, Mail } from "lucide-react";
 
 export default function NewslettersPage() {
   const { newsletters, isLoading, error } = useNewsletters();
+  const hasNewsletters = newsletters.length > 0;
 
   return (
     <div className="min-h-screen bg-background">
@@ -28,20 +29,20 @@ export default function NewslettersPage() {
           </div>
         </div>
 
-        {isLoading ? (
+        {isLoading && !hasNewsletters ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="h-64 animate-pulse bg-muted rounded-lg"></div>
             ))}
           </div>
-        ) : error ? (
+        ) : error && !hasNewsletters ? (
           <div className="text-center py-12">
             <p className="text-muted-foreground">ニュースレターの読み込みに失敗しました</p>
             <Button variant="outline" className="mt-4">
               再試行
             </Button>
           </div>
-        ) : newsletters.length === 0 ? (
+        ) : !hasNewsletters ? (
           <div className="text-center py-12">
             <Mail className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
             <h3 className="text-lg font-semibold mb-2">ニュースレターがありません</h3>
@@ -52,14 +53,21 @@ export default function NewslettersPage() {
             </Button>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {newsletters.map((newsletter) => (
-              <NewsletterCard key={newsletter.id} newsletter={newsletter} />
-            ))}
-          </div>
+          <>
+            {error ? (
+              <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                最新データ取得に失敗したため、利用可能なニュースレターを表示しています。
+              </div>
+            ) : null}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {newsletters.map((newsletter) => (
+                <NewsletterCard key={newsletter.id} newsletter={newsletter} />
+              ))}
+            </div>
+          </>
         )}
 
-        {newsletters.length > 0 && (
+        {hasNewsletters && (
           <div className="mt-12 text-center">
             <Button variant="outline">さらに読み込む</Button>
           </div>


### PR DESCRIPTION
## Summary
- `/articles` と `/newsletters` の描画分岐を見直し、`error` が立っても既存データ（placeholder/fallback）がある場合はカード一覧を継続表示
- データが空のときのみ従来のエラー画面・空状態を表示するよう条件を厳密化
- API不安定時でもユーザーが即座に空白画面に遷移しないよう UX を改善

## Test plan
- [x] `frontend`: `npm run lint`
- [x] `frontend`: `npm run format:check`
- [x] `frontend`: `npm run type-check`
- [x] `frontend`: `npm run test -- --runInBand`
- [x] production `/articles` のHTTP 200確認
- [x] production `/api/proxy/articles?sortBy=newest` のHTTP 200確認

Made with [Cursor](https://cursor.com)