### PR TITLE
fix(data): sync automated contents into core content tables

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,10 @@ AICA-SyS Backend Main Application
 AI-driven Content Curation & Automated Sales System
 """
 
+import asyncio
 import logging
 import os
+from contextlib import suppress
 
 import uvicorn
 from dotenv import load_dotenv
@@ -30,6 +32,7 @@ load_dotenv()
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+content_sync_task: asyncio.Task | None = None
 
 # Create FastAPI app
 app = FastAPI(
@@ -98,6 +101,60 @@ async def detailed_health_check():
     """Detailed health check with performance metrics"""
     health_status = performance_metrics.get_stats()
     return health_status
+
+
+async def _periodic_content_sync():
+    from database import SessionLocal
+    from services.content_sync_service import get_content_sync_service
+
+    interval_seconds = int(os.getenv("CONTENT_SYNC_INTERVAL_SECONDS", "600"))
+    sync_service = get_content_sync_service()
+
+    while True:
+        db = SessionLocal()
+        try:
+            stats = sync_service.sync_published_content(db)
+            if stats["scanned"] > 0:
+                logger.info(
+                    "[content-sync][startup-task] scanned=%s article=%s newsletter=%s trend=%s",
+                    stats["scanned"],
+                    stats["article_upserts"],
+                    stats["newsletter_upserts"],
+                    stats["trend_upserts"],
+                )
+        except Exception:
+            logger.exception("Periodic content sync failed")
+        finally:
+            db.close()
+
+        await asyncio.sleep(interval_seconds)
+
+
+@app.on_event("startup")
+async def start_background_content_sync():
+    global content_sync_task
+    if os.getenv("ENABLE_CONTENT_SYNC", "true").lower() != "true":
+        logger.info("Background content sync disabled by ENABLE_CONTENT_SYNC")
+        return
+
+    if content_sync_task and not content_sync_task.done():
+        return
+
+    content_sync_task = asyncio.create_task(_periodic_content_sync())
+    logger.info("Background content sync task started")
+
+
+@app.on_event("shutdown")
+async def stop_background_content_sync():
+    global content_sync_task
+    if not content_sync_task:
+        return
+
+    content_sync_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await content_sync_task
+    content_sync_task = None
+    logger.info("Background content sync task stopped")
 
 
 # Import routers

--- a/backend/routers/content.py
+++ b/backend/routers/content.py
@@ -2,6 +2,8 @@
 Content API router for AICA-SyS
 """
 
+import logging
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -11,8 +13,12 @@ from database import get_db
 from models.automated_content import AutomatedContentDB, ContentStatus, ContentType
 from models.collection import AnalysisResult
 from models.content import Article, Newsletter, Trend
+from services.content_sync_service import get_content_sync_service
 
 router = APIRouter(prefix="/api/content", tags=["content"])
+_last_sync_at: Optional[datetime] = None
+_sync_interval = timedelta(minutes=5)
+logger = logging.getLogger(__name__)
 
 
 def _to_int(value, default=0):
@@ -91,6 +97,29 @@ def _automated_to_trend(content: AutomatedContentDB) -> dict:
     }
 
 
+def _ensure_core_tables_synced(db: Session) -> None:
+    global _last_sync_at
+    now = datetime.utcnow()
+    if _last_sync_at and now - _last_sync_at < _sync_interval:
+        return
+
+    try:
+        sync_service = get_content_sync_service()
+        stats = sync_service.sync_published_content(db)
+        _last_sync_at = now
+
+        if stats["scanned"] > 0:
+            logger.info(
+                f"[content-sync] scanned={stats['scanned']} "
+                f"article={stats['article_upserts']} "
+                f"newsletter={stats['newsletter_upserts']} "
+                f"trend={stats['trend_upserts']}"
+            )
+    except Exception:
+        # Synchronization failure must not block read API responses.
+        logger.exception("Failed to synchronize automated content into core tables")
+
+
 @router.get("/articles")
 async def get_articles(
     skip: int = Query(0, ge=0),
@@ -99,6 +128,7 @@ async def get_articles(
     db: Session = Depends(get_db),
 ):
     """Get list of articles"""
+    _ensure_core_tables_synced(db)
     query = db.query(Article)
 
     if is_premium is not None:
@@ -155,6 +185,7 @@ async def get_newsletters(
     db: Session = Depends(get_db),
 ):
     """Get list of newsletters"""
+    _ensure_core_tables_synced(db)
     newsletters = db.query(Newsletter).offset(skip).limit(limit).all()
     total = db.query(Newsletter).count()
 
@@ -204,6 +235,7 @@ async def get_trends(
     db: Session = Depends(get_db),
 ):
     """Get list of trends"""
+    _ensure_core_tables_synced(db)
     query = db.query(Trend)
 
     if category:

--- a/backend/scripts/sync_automated_content.py
+++ b/backend/scripts/sync_automated_content.py
@@ -1,0 +1,32 @@
+"""
+One-shot batch runner for automated content synchronization.
+
+Usage:
+  ./venv/bin/python scripts/sync_automated_content.py
+"""
+
+from database import SessionLocal
+from services.content_sync_service import get_content_sync_service
+
+
+def main() -> None:
+    db = SessionLocal()
+    try:
+        service = get_content_sync_service()
+        stats = service.sync_published_content(db)
+        print(
+            "sync_completed",
+            {
+                "scanned": stats["scanned"],
+                "article_upserts": stats["article_upserts"],
+                "newsletter_upserts": stats["newsletter_upserts"],
+                "trend_upserts": stats["trend_upserts"],
+                "skipped": stats["skipped"],
+            },
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/content_sync_service.py
+++ b/backend/services/content_sync_service.py
@@ -18,11 +18,15 @@ logger = logging.getLogger(__name__)
 class ContentSyncService:
     """Synchronize published automated content into articles/newsletters/trends."""
 
-    def sync_published_content(self, db: Session, limit: Optional[int] = None) -> Dict[str, int]:
+    def sync_published_content(
+        self, db: Session, limit: Optional[int] = None
+    ) -> Dict[str, int]:
         query = db.query(AutomatedContentDB).filter(
             AutomatedContentDB.status == ContentStatus.PUBLISHED.value
         )
-        query = query.order_by(AutomatedContentDB.updated_at.asc(), AutomatedContentDB.id.asc())
+        query = query.order_by(
+            AutomatedContentDB.updated_at.asc(), AutomatedContentDB.id.asc()
+        )
 
         if limit:
             query = query.limit(limit)
@@ -67,7 +71,9 @@ class ContentSyncService:
         article.content = automated.content or ""
         article.summary = automated.summary or (automated.content or "")[:240]
         article.tags = self._as_list(metadata.get("tags"))
-        article.published_at = automated.published_at or automated.created_at or datetime.utcnow()
+        article.published_at = (
+            automated.published_at or automated.created_at or datetime.utcnow()
+        )
         article.author = str(metadata.get("author", "AICA-SyS"))
         article.read_time = self._as_int(metadata.get("read_time"), default=5)
         article.is_premium = self._as_bool(metadata.get("is_premium"), default=False)
@@ -122,7 +128,11 @@ class ContentSyncService:
 
     @staticmethod
     def _stable_uuid(automated: AutomatedContentDB) -> str:
-        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"aica-sys:{automated.content_type}:{automated.id}"))
+        return str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL, f"aica-sys:{automated.content_type}:{automated.id}"
+            )
+        )
 
     @staticmethod
     def _as_list(value: Any) -> list:

--- a/backend/services/content_sync_service.py
+++ b/backend/services/content_sync_service.py
@@ -1,0 +1,167 @@
+"""
+Synchronize automated_contents into core content tables.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from models.automated_content import AutomatedContentDB, ContentStatus, ContentType
+from models.content import Article, Newsletter, Trend, TrendCategory, TrendImpact
+
+logger = logging.getLogger(__name__)
+
+
+class ContentSyncService:
+    """Synchronize published automated content into articles/newsletters/trends."""
+
+    def sync_published_content(self, db: Session, limit: Optional[int] = None) -> Dict[str, int]:
+        query = db.query(AutomatedContentDB).filter(
+            AutomatedContentDB.status == ContentStatus.PUBLISHED.value
+        )
+        query = query.order_by(AutomatedContentDB.updated_at.asc(), AutomatedContentDB.id.asc())
+
+        if limit:
+            query = query.limit(limit)
+
+        rows = query.all()
+        stats = {
+            "scanned": len(rows),
+            "article_upserts": 0,
+            "newsletter_upserts": 0,
+            "trend_upserts": 0,
+            "skipped": 0,
+        }
+
+        for row in rows:
+            if row.content_type == ContentType.ARTICLE.value:
+                self._upsert_article(db, row)
+                stats["article_upserts"] += 1
+            elif row.content_type == ContentType.NEWSLETTER.value:
+                self._upsert_newsletter(db, row)
+                stats["newsletter_upserts"] += 1
+            elif row.content_type == ContentType.TREND.value:
+                self._upsert_trend(db, row)
+                stats["trend_upserts"] += 1
+            else:
+                stats["skipped"] += 1
+
+        if rows:
+            db.commit()
+
+        return stats
+
+    def _upsert_article(self, db: Session, automated: AutomatedContentDB) -> None:
+        article_id = self._stable_uuid(automated)
+        article = db.query(Article).filter(Article.id == article_id).first()
+        metadata = automated.content_metadata or {}
+
+        if not article:
+            article = Article(id=article_id, title="", content="", summary="")
+            db.add(article)
+
+        article.title = automated.title or "Untitled"
+        article.content = automated.content or ""
+        article.summary = automated.summary or (automated.content or "")[:240]
+        article.tags = self._as_list(metadata.get("tags"))
+        article.published_at = automated.published_at or automated.created_at or datetime.utcnow()
+        article.author = str(metadata.get("author", "AICA-SyS"))
+        article.read_time = self._as_int(metadata.get("read_time"), default=5)
+        article.is_premium = self._as_bool(metadata.get("is_premium"), default=False)
+        article.views = self._as_int(metadata.get("views"), default=0)
+        article.likes = self._as_int(metadata.get("likes"), default=0)
+        article.created_at = automated.created_at or datetime.utcnow()
+        article.updated_at = automated.updated_at or datetime.utcnow()
+
+    def _upsert_newsletter(self, db: Session, automated: AutomatedContentDB) -> None:
+        newsletter_id = self._stable_uuid(automated)
+        newsletter = db.query(Newsletter).filter(Newsletter.id == newsletter_id).first()
+        metadata = automated.content_metadata or {}
+
+        if not newsletter:
+            newsletter = Newsletter(id=newsletter_id, title="", content="")
+            db.add(newsletter)
+
+        newsletter.title = automated.title or "Untitled"
+        newsletter.content = automated.content or ""
+        newsletter.published_at = (
+            automated.published_at or automated.created_at or datetime.utcnow()
+        )
+        newsletter.subscribers = self._as_int(metadata.get("subscribers"), default=0)
+        newsletter.open_rate = self._as_int(metadata.get("open_rate"), default=0)
+        newsletter.created_at = automated.created_at or datetime.utcnow()
+
+    def _upsert_trend(self, db: Session, automated: AutomatedContentDB) -> None:
+        trend_id = self._stable_uuid(automated)
+        trend = db.query(Trend).filter(Trend.id == trend_id).first()
+        metadata = automated.content_metadata or {}
+
+        if not trend:
+            trend = Trend(
+                id=trend_id,
+                title="",
+                description="",
+                category=TrendCategory.ECOSYSTEM.value,
+                impact=TrendImpact.MEDIUM.value,
+            )
+            db.add(trend)
+
+        trend.title = automated.title or "Untitled"
+        trend.description = automated.summary or automated.content or ""
+        trend.category = self._normalize_trend_category(
+            metadata.get("category", TrendCategory.ECOSYSTEM.value)
+        )
+        trend.impact = self._normalize_trend_impact(
+            metadata.get("impact", TrendImpact.MEDIUM.value)
+        )
+        trend.related_articles = self._as_list(metadata.get("related_articles"))
+        trend.created_at = automated.created_at or datetime.utcnow()
+
+    @staticmethod
+    def _stable_uuid(automated: AutomatedContentDB) -> str:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"aica-sys:{automated.content_type}:{automated.id}"))
+
+    @staticmethod
+    def _as_list(value: Any) -> list:
+        if isinstance(value, list):
+            return value
+        return []
+
+    @staticmethod
+    def _as_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _as_bool(value: Any, default: bool = False) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in {"1", "true", "yes", "on"}
+        if isinstance(value, (int, float)):
+            return bool(value)
+        return default
+
+    @staticmethod
+    def _normalize_trend_category(value: Any) -> str:
+        raw = str(value or "").lower()
+        allowed = {item.value for item in TrendCategory}
+        return raw if raw in allowed else TrendCategory.ECOSYSTEM.value
+
+    @staticmethod
+    def _normalize_trend_impact(value: Any) -> str:
+        raw = str(value or "").lower()
+        allowed = {item.value for item in TrendImpact}
+        return raw if raw in allowed else TrendImpact.MEDIUM.value
+
+
+_content_sync_service = ContentSyncService()
+
+
+def get_content_sync_service() -> ContentSyncService:
+    return _content_sync_service


### PR DESCRIPTION
## Summary
- Add `ContentSyncService` to upsert published `automated_contents` into `articles`, `newsletters`, and `trends` using stable deterministic IDs.
- Trigger sync on `/api/content/*` reads with throttling so user-facing endpoints can self-heal empty core tables.
- Start periodic background sync at backend startup and add a one-shot runner script for manual backfill.

## Test plan
- [x] `cd frontend && npm run format:check`
- [x] `cd frontend && npm run lint`
- [x] `cd backend && ./venv/bin/python -m pytest`
- [x] `cd backend && ./venv/bin/python -m py_compile main.py routers/content.py services/content_sync_service.py scripts/sync_automated_content.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic background content synchronization running at periodic intervals
  * Manual batch synchronization script for on-demand content updates
  * Content API endpoints now ensure data freshness by synchronizing before serving requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->